### PR TITLE
📄Docs: [#111] run.py 수정, README.md 추가

### DIFF
--- a/BE/Dockerfile
+++ b/BE/Dockerfile
@@ -27,6 +27,6 @@ RUN apt update && \
 ENV FLASK_APP=run.py
 
 # 포트 설정
-EXPOSE 5000
+EXPOSE 19020
 
 CMD ["/usr/bin/python3", "run.py", "--host=0.0.0.0", "--port=19020"]

--- a/BE/README.md
+++ b/BE/README.md
@@ -1,0 +1,25 @@
+## 젠킨스(jenkins)를 통한 배포 자동화
+1. 로컬 작업 브랜치(feature branch)를 게시 
+2. gihub에서 Pull requests를 통해 2명 이상의 리뷰어가 승인
+3. 요청자가 feature branch와 develop를 merge 
+4. Trigger : merge가 발생된 시점
+
+## 로컬 실행 명령어
+
+    # 1회성 실행  
+    docker-compose up --build 
+
+    # bg 실행  
+    docker-compose up --build -d 
+
+    # 이미 빌드한 container가 존재할 경우  
+    docker start [컨테이너명]
+
+## 로컬에서의 실행 환경
+
+- docker-compose를 통해 build
+- python3 
+    - ubuntu에 설치되어 있는 기본 python3 
+    - /usr/bin/python3
+- .venv 환경을 사용하지 않음(로컬에서 개인적으로 테스트할 때는 사용)
+

--- a/BE/run.py
+++ b/BE/run.py
@@ -7,7 +7,7 @@ import quart
 
 # cors 적용 (모두 허용)
 app = quart_cors.cors(quart.Quart(__name__), 
-    allow_origin='http://localhost:9090', 
+    allow_origin='*', 
     allow_methods=['POST','GET','OPTIONS','PUT'], 
     allow_headers=['Content-Type', 
                    'Access-Control-Allow-Origin',

--- a/BE/run.py
+++ b/BE/run.py
@@ -2,12 +2,21 @@ from quart import Quart
 from app.v1.main import v1_bp
 from app.v2.main import v2_bp
 from app.test.main import t_bp
-from flask_cors import CORS 
-
-app = Quart(__name__)
+import quart_cors
+import quart
 
 # cors 적용 (모두 허용)
-CORS(app)
+app = quart_cors.cors(quart.Quart(__name__), 
+    allow_origin='http://localhost:9090', 
+    allow_methods=['POST','GET','OPTIONS','PUT'], 
+    allow_headers=['Content-Type', 
+                   'Access-Control-Allow-Origin',
+                   'Access-Control-Max-Age', 
+                   'Access-Control-Allow-Methods',
+                   'Access-Control-Allow-Headers',
+                   'Access-Control-Allow-Credentials'],
+    allow_credentials=True
+    )
 
 # 블루프린트를 등록하여 버전별로 API를 관리
 app.register_blueprint(v1_bp, url_prefix='/v1')


### PR DESCRIPTION
- run.py
   - 변경 사유 : .env 에 설정된 값을 불러와 적용했을 때 origin 주소가 인식되지 않는 문제
   - 변경 내용 : 
      - 1차 수정(2024.08.17) : allow_origin 매개값 수정 CLINET -> 'http://localhost:9090'
      - 2차 수정(2024.08.19) : allow_origin 매개값 와일드카드로 수정

- README.md
   - 배포 및 실행 명령어 작성

- git branch Pull Requests history
1) run.py -> Pull Requests 
2) 추가 수정 사항이 있어 원격 브랜치 분기 
    - 원격 브랜치 : feature/be-#111-API_서버_CORS_적용하기
3) 최초 게시한 브랜치와 추가 수정한 브랜치를 merge
4) 병합한 branch 게시 

