### PR TITLE
Feature/be #178 인스턴스와 컨테이너간 통신

### DIFF
--- a/BE/docker-compose.yaml
+++ b/BE/docker-compose.yaml
@@ -16,3 +16,9 @@ services:
     volumes:
       - /DE31-final-team1/BE:/home/mydir/api-server
       - /home/ubuntu/.aws:/root/.aws:ro
+    networks:
+      - app-network
+
+networks:
+  app-network:
+    driver: bridge


### PR DESCRIPTION
- ec2 인스턴스와 빌드되는 컨테이너 간 통신연결을 위해서 docker-compose.yaml networks bridge 설정