### PR TITLE
Feature/be #178 terramform build

### DIFF
--- a/BE/docker-compose.yaml
+++ b/BE/docker-compose.yaml
@@ -6,8 +6,7 @@ services:
       context: .
       dockerfile: Dockerfile
     image: flask-api:1.0 
-    ports:
-      - "19020:19020"
+    network_mode: host
     environment:
       FLASK_APP: run.py
       FLASK_ENV: development
@@ -16,9 +15,3 @@ services:
     volumes:
       - /DE31-final-team1/BE:/home/mydir/api-server
       - /home/ubuntu/.aws:/root/.aws:ro
-    networks:
-      - app-network
-
-networks:
-  app-network:
-    driver: bridge

--- a/BE/docker-compose.yaml
+++ b/BE/docker-compose.yaml
@@ -16,3 +16,9 @@ services:
     volumes:
       - /DE31-final-team1/BE:/home/mydir/api-server
       - /home/ubuntu/.aws:/root/.aws:ro
+    networks:
+      - app-network
+
+networks:
+  app-network:
+    driver: bridge


### PR DESCRIPTION
- EC2 인스턴스의 네트워크 설정을 그대로 사용하도록 network_mode 설정,  Terraform에서 정의한 VPC, 서브넷, 보안 그룹 등의 설정이 컨테이너에 직접 적용